### PR TITLE
📦 release: v0.2.0

### DIFF
--- a/invenio_damap/__init__.py
+++ b/invenio_damap/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2022 Graz University of Technology.
-# Copyright (C) 2024 TU Wien.
+# Copyright (C) 2024-2025 TU Wien.
 #
 # Invenio-DAMAP is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -10,6 +10,6 @@
 
 from .ext import InvenioDAMAP
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"
 
 __all__ = ("__version__", "InvenioDAMAP")


### PR DESCRIPTION
Support InvenioRDM v13: Relax dependency upper bound for `invenio-app-rdm`, now allowing `>=12.0.0`.