### PR TITLE
Fix v13 compatibility

### DIFF
--- a/invenio_damap/assets/semantic-ui/js/invenio_damap/DMPModal.js
+++ b/invenio_damap/assets/semantic-ui/js/invenio_damap/DMPModal.js
@@ -180,7 +180,9 @@ export class DMPModal extends React.Component {
   async fetchDMPs() {
     this.setLoading(true);
     try {
-      let dmpSearchResult = await http.get("/api/invenio_damap/damap/dmp");
+      let dmpSearchResult = await http.get("/api/invenio_damap/damap/dmp", {
+        headers: { Accept: "application/json" },
+      });
       const newDmps = dmpSearchResult.data.hits.hits;
       this.setState({ dmps: newDmps });
       // Pass the updated DMPs back to the button
@@ -214,7 +216,8 @@ export class DMPModal extends React.Component {
 
     let response = await http.post(
       `/api/invenio_damap/damap/dmp/${dmp_id}/dataset/${record.id}`,
-      body
+      body,
+      { headers: { Accept: "application/json" } },
     );
 
     return response;
@@ -246,7 +249,7 @@ export class DMPModal extends React.Component {
       responses.push(
         this.onAddUpdateDataset(dmp.id, record).catch((e) => {
           errors.push({ dmp, error: e });
-        })
+        }),
       );
     }
     await Promise.all(responses);
@@ -256,14 +259,14 @@ export class DMPModal extends React.Component {
         "check circle outline",
         "success",
         "Success!",
-        "Record was linked to DMP(s)."
+        "Record was linked to DMP(s).",
       );
     } else if (errors.length === selectedDmps.length) {
       this.showMessage(
         "times circle outline",
         "error",
         "Error",
-        "Linking record to DMP(s) failed."
+        "Linking record to DMP(s) failed.",
       );
     } else {
       this.showMessage(
@@ -271,7 +274,7 @@ export class DMPModal extends React.Component {
         "warning",
         "Record was linked to DMP(s) with errors. Not linked/updated:",
         "",
-        errors
+        errors,
       );
     }
     this.setLoading(false);

--- a/invenio_damap/assets/semantic-ui/js/invenio_damap/DMPModal.js
+++ b/invenio_damap/assets/semantic-ui/js/invenio_damap/DMPModal.js
@@ -373,6 +373,8 @@ export class DMPModal extends React.Component {
 
           <Button
             primary
+            size="small"
+            className="ml-15"
             floated="right"
             icon
             loading={loading}

--- a/invenio_damap/assets/semantic-ui/js/invenio_damap/index.js
+++ b/invenio_damap/assets/semantic-ui/js/invenio_damap/index.js
@@ -37,6 +37,6 @@ if (element) {
   // TODO: 'render()' is deprecated, use 'root.render()'
   ReactDOM.render(
     <Grid.Column className="pt-5">{ButtonComponent}</Grid.Column>,
-    element
+    element,
   );
 }

--- a/invenio_damap/resources/config.py
+++ b/invenio_damap/resources/config.py
@@ -10,6 +10,8 @@
 
 import marshmallow as ma
 from flask_resources import HTTPJSONException, ResourceConfig, create_error_handler
+from flask_resources.responses import ResponseHandler
+from flask_resources.serializers import JSONSerializer
 from invenio_records_resources.resources.errors import ErrorHandlersMixin
 from invenio_records_resources.resources.records.args import SearchRequestArgsSchema
 
@@ -61,4 +63,8 @@ class InvenioDAMAPResourceConfig(ResourceConfig):
     }
     request_search_args = InvenioDAMAPSearchRequestArgsSchema
 
+    response_handlers = {
+        **ResourceConfig.response_handlers,
+        "application/vnd.inveniordm.v1+json": ResponseHandler(JSONSerializer()),
+    }
     error_handlers = invenio_damap_error_handlers


### PR DESCRIPTION
# Pagination
Flask-SQLAlchemy v3 has turned `Pagination` into a basically abstract class, and provides two implementations: `QueryPagination` and `SelectPagination`, both of which expect an actual DB query to be available one way or another.
This is not the case here (`query=None`), so we cannot use either and need to provide our own custom implementation.

# HTTP Accept header
Further, it looks like at some point, behavior changed regarding the `Accept` HTTP header and `application/vnd.inveniordm.v1+json`:
Either the default resource response handlers have been made stricter (only allow `application/json`), or the default headers for the custom `axios` HTTP header have changed.
The scenario was that the HTTP requests here were sent with `application/vnd.inveniordm.v1+json`, but the resource would only allow `application/json` and reply with HTTP 406.
This PR tackles this issue by both making the resource less picky, as well as having the HTTP requests request "normal" JSON responses.